### PR TITLE
Unit signals and slots

### DIFF
--- a/ReactSharp.Tests/Source/FutureTest.cs
+++ b/ReactSharp.Tests/Source/FutureTest.cs
@@ -2,10 +2,9 @@
 // ReactSharp - a library for async & FRP-ish programming in C#
 // http://github.com/samskivert/ReactSharp/blob/master/LICENSE
 
-using NUnit.Framework;
-using System.Collections.Generic;
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
+using NUnit.Framework;
 
 namespace React {
 

--- a/ReactSharp.Tests/Source/SignalTest.cs
+++ b/ReactSharp.Tests/Source/SignalTest.cs
@@ -258,6 +258,17 @@ namespace React {
       Assert.AreEqual(1, counter.notifies);
     }
 
+    [Test] public void testUnitSignal () {
+      var signal = new UnitSignal();
+      var counter = new Counter();
+      var connection = signal.OnEmit(counter.Increment());
+      signal.Emit();
+      connection.Dispose();
+      signal.Emit();
+      Assert.AreEqual(1, counter.notifies);
+      Assert.False(signal.HasConnections());
+    }
+
     [Test] public void testUnitSlot () {
       var signal = new Signal<string>();
       var counter = new Counter();
@@ -267,6 +278,7 @@ namespace React {
       connection.Dispose();
       signal.Emit("barzle");
       Assert.AreEqual(1, counter.notifies);
+      Assert.False(signal.HasConnections());
     }
   }
 }

--- a/ReactSharp.Tests/Source/SignalTest.cs
+++ b/ReactSharp.Tests/Source/SignalTest.cs
@@ -19,6 +19,12 @@ namespace React {
           notifies += 1;
         };
       }
+
+      public Action Increment () {
+        return () => {
+          notifies += 1;
+        };
+      }
     }
 
     public class Accum<T> {
@@ -249,6 +255,17 @@ namespace React {
 
       signal.Emit(null);
       signal.Emit("foozle");
+      Assert.AreEqual(1, counter.notifies);
+    }
+
+    [Test] public void testUnitSlot () {
+      var signal = new Signal<string>();
+      var counter = new Counter();
+
+      var connection = signal.OnEmit(counter.Increment());
+      signal.Emit("foozle");
+      connection.Dispose();
+      signal.Emit("barzle");
       Assert.AreEqual(1, counter.notifies);
     }
   }

--- a/ReactSharp.Tests/Source/SignalTest.cs
+++ b/ReactSharp.Tests/Source/SignalTest.cs
@@ -14,7 +14,7 @@ namespace React {
 
     public class Counter {
       public int notifies;
-      public OnValue<T> Increment<T> () {
+      public Action<T> Increment<T> () {
         return (value) => {
           notifies += 1;
         };
@@ -30,7 +30,7 @@ namespace React {
     public class Accum<T> {
       public List<T> values = new List<T>();
 
-      public OnValue<T> Adder () {
+      public Action<T> Adder () {
         return (value) => {
           values.Add(value);
         };
@@ -42,7 +42,7 @@ namespace React {
       }
     }
 
-    public static OnValue<T> Require<T> (T reqValue) {
+    public static Action<T> Require<T> (T reqValue) {
       return (value) => {
         Assert.AreEqual(reqValue, value);
       };

--- a/ReactSharp.Tests/Source/ValueTest.cs
+++ b/ReactSharp.Tests/Source/ValueTest.cs
@@ -2,10 +2,9 @@
 // ReactSharp - a library for async & FRP-ish programming in C#
 // http://github.com/samskivert/ReactSharp/blob/master/LICENSE
 
-using NUnit.Framework;
-using System.Collections.Generic;
 using System;
 using System.Diagnostics;
+using NUnit.Framework;
 
 namespace React {
 
@@ -19,7 +18,7 @@ namespace React {
           notifies += 1;
         };
       }
-      public OnValue<T> OnValue<T> () {
+      public Action<T> Action<T> () {
         return (value) => {
           notifies += 1;
         };
@@ -57,7 +56,7 @@ namespace React {
     [Test] public void testChangesNext () {
       var value = new Value<int>(42);
       var counter = new Counter();
-      value.Changes().Next().OnSuccess(counter.OnValue<int>());
+      value.Changes().Next().OnSuccess(counter.Action<int>());
       value.Update(15);
       value.Update(42);
       Assert.AreEqual(1, counter.notifies);

--- a/ReactSharp/ReactSharp.csproj
+++ b/ReactSharp/ReactSharp.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Source\Future.cs" />
     <Compile Include="Source\Promise.cs" />
     <Compile Include="Source\Try.cs" />
+    <Compile Include="Source\Unit.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/ReactSharp/Source/Promise.cs
+++ b/ReactSharp/Source/Promise.cs
@@ -17,7 +17,7 @@ namespace React {
   /// satisfied listeners will be inadvertently retained.</p>
   public class Promise<T> : AbstractFuture<T> {
 
-    private OnValue<ITry<T>> _onComplete;
+    private Action<ITry<T>> _onComplete;
     private ITry<T> _result;
 
     /// Causes this promise to be completed successfully with <c>value</c>.
@@ -39,7 +39,7 @@ namespace React {
         try {
           var lners = _onComplete.GetInvocationList();
           List<Exception> errors = null;
-          foreach (OnValue<ITry<T>> lner in lners) {
+          foreach (Action<ITry<T>> lner in lners) {
             try {
               lner(_result);
             } catch (Exception e) {
@@ -59,7 +59,7 @@ namespace React {
 
     public override bool IsComplete { get { return _result != null; } }
 
-    public override IDisposable OnComplete (OnValue<ITry<T>> listener) {
+    public override IDisposable OnComplete (Action<ITry<T>> listener) {
       var result = _result;
       if (result != null) {
         listener(result);
@@ -74,7 +74,7 @@ namespace React {
     protected virtual void ConnectionAdded () {}
     protected virtual void ConnectionRemoved () {}
 
-    private void RemoveConnection (OnValue<ITry<T>> listener) {
+    private void RemoveConnection (Action<ITry<T>> listener) {
       if (_onComplete != null) {
         _onComplete -= listener;
       }
@@ -83,9 +83,9 @@ namespace React {
 
     private class Connection : IDisposable {
       private Promise<T> _promise;
-      private OnValue<ITry<T>> _listener;
+      private Action<ITry<T>> _listener;
 
-      public Connection (Promise<T> promise, OnValue<ITry<T>> listener) {
+      public Connection (Promise<T> promise, Action<ITry<T>> listener) {
         _promise = promise;
         _listener = listener;
       }

--- a/ReactSharp/Source/Signal.cs
+++ b/ReactSharp/Source/Signal.cs
@@ -7,10 +7,6 @@ using System.Collections.Generic;
 
 namespace React {
 
-  /// Called when a signal to which this delegate is connected has emitted an event.
-  /// @param value the value emitted by the signal.
-  public delegate void OnValue<in T> (T value);
-
   /// A view of a {@link Signal}, on which slots may listen, but to which one cannot emit events.
   /// This is generally used to provide signal-like views of changing entities. See {@link
   /// AbstractValue} for an example.
@@ -33,7 +29,7 @@ namespace React {
     /// signal, the slot will be notified.
     ///
     /// @return a handle can be used to cancel the connection.
-    IDisposable OnEmit (OnValue<T> slot);
+    IDisposable OnEmit (Action<T> slot);
 
     /// Connects this signal to the supplied unit slot, such that when an event is emitted from this
     /// signal, the slot will be notified.
@@ -79,13 +75,13 @@ namespace React {
     public IDisposable OnEmit (Action unitSlot) {
       return OnEmit((T value) => { unitSlot(); });
     }
-    public IDisposable OnEmit (OnValue<T> slot) {
+    public IDisposable OnEmit (Action<T> slot) {
       _onEmit += slot;
       ConnectionAdded();
       return new Connection(this, slot);
     }
 
-    private void RemoveConnection (OnValue<T> slot) {
+    private void RemoveConnection (Action<T> slot) {
       _onEmit -= slot;
       ConnectionRemoved();
     }
@@ -95,9 +91,9 @@ namespace React {
 
     private class Connection : IDisposable {
       private AbstractSignal<T> _signal;
-      private OnValue<T> _listener;
+      private Action<T> _listener;
 
-      public Connection (AbstractSignal<T> signal, OnValue<T> listener) {
+      public Connection (AbstractSignal<T> signal, Action<T> listener) {
         _signal = signal;
         _listener = listener;
       }
@@ -115,7 +111,7 @@ namespace React {
       if (_onEmit != null) {
         var lners = _onEmit.GetInvocationList();
         List<Exception> errors = null;
-        foreach (OnValue<T> lner in lners) {
+        foreach (Action<T> lner in lners) {
           try {
             lner(value);
           } catch (Exception e) {
@@ -127,7 +123,7 @@ namespace React {
       }
     }
 
-    private OnValue<T> _onEmit;
+    private Action<T> _onEmit;
   }
 
   /// Plumbing to implement dependent signals in such a way that they automatically manage a

--- a/ReactSharp/Source/Signal.cs
+++ b/ReactSharp/Source/Signal.cs
@@ -34,6 +34,12 @@ namespace React {
     ///
     /// @return a handle can be used to cancel the connection.
     IDisposable OnEmit (OnValue<T> slot);
+
+    /// Connects this signal to the supplied unit slot, such that when an event is emitted from this
+    /// signal, the slot will be notified.
+    ///
+    /// @return a handle can be used to cancel the connection.
+    IDisposable OnEmit (Action unitSlot);
   }
 
   /// A signal that emits events of type <c>T</c>. Listeners may be connected to a signal to be
@@ -69,6 +75,9 @@ namespace React {
         result.Succeed(value);
       });
       return result;
+    }
+    public IDisposable OnEmit (Action unitSlot) {
+      return OnEmit((T value) => { unitSlot(); });
     }
     public IDisposable OnEmit (OnValue<T> slot) {
       _onEmit += slot;

--- a/ReactSharp/Source/Signal.cs
+++ b/ReactSharp/Source/Signal.cs
@@ -38,6 +38,15 @@ namespace React {
     IDisposable OnEmit (Action unitSlot);
   }
 
+  /// A view of a {@link UnitSignal} on which slots may listen, but to which one cannot emit events.
+  public interface IUnitSignal : ISignal<Unit> {
+
+    /// Creates a signal that maps this unit signal via a function. When this signal emits a value, the
+    /// mapped signal will emit that value as transformed by the supplied function. The mapped
+    /// signal will retain a connection to this signal for as long as it has connections of its own.
+    ISignal<M> Map<M> (Func<M> func);
+  }
+
   /// A signal that emits events of type <c>T</c>. Listeners may be connected to a signal to be
   /// notified upon event emission.
   public class Signal<T> : AbstractSignal<T> {
@@ -45,6 +54,20 @@ namespace React {
     /// Causes this signal to emit the supplied event to connected slots.
     public void Emit (T value) {
       NotifyEmit(value);
+    }
+  }
+
+  /// A signal that emits value-less events. Listeners may be connected to a signal to be
+  /// notified upon event emission.
+  public class UnitSignal : AbstractSignal<Unit>, IUnitSignal {
+
+    /// Causes this signal to emit to connected slots.
+    public void Emit () {
+      NotifyEmit(Unit.Default);
+    }
+
+    public ISignal<M> Map<M> (Func<M> func) {
+      return Map(value => func());
     }
   }
 

--- a/ReactSharp/Source/Unit.cs
+++ b/ReactSharp/Source/Unit.cs
@@ -1,0 +1,38 @@
+﻿//
+// ReactSharp - a library for async & FRP-ish programming in C#
+// http://github.com/samskivert/ReactSharp/blob/master/LICENSE
+
+using System;
+
+namespace React {
+
+  /// An empty value that represents void
+  public struct Unit : IEquatable<Unit> {
+    public static Unit Default { get; } = new Unit();
+
+    public bool Equals (Unit other) {
+      return true;
+    }
+
+    public override bool Equals (object obj) {
+      return obj is Unit;
+    }
+
+    public override int GetHashCode () {
+      return 0;
+    }
+
+    public override string ToString () {
+      return "()";
+    }
+
+    public static bool operator == (Unit a, Unit b) {
+      return true;
+    }
+
+    public static bool operator != (Unit a, Unit b) {
+      return false;
+    }
+  }
+
+}


### PR DESCRIPTION
Signals can now be connected to unit slots via an `OnEmit(Action)` overload. UnitSignal is a new type that emits the empty "Unit" type (whose implementation I copied from Microsoft's Rx library).

Also, I removed `OnValue<T>` and replaced its usages with the .NET-standard `Action<T>` (but if I misunderstood something this can easily be re-added).